### PR TITLE
rewrite hero copy with education-first positioning

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "Khashmere Website (docs)",
+      "runtimeExecutable": "npx",
+      "runtimeArgs": ["serve", "/Users/linhphan/Documents/khashmere-website/docs", "-p", "3000", "--no-clipboard"],
+      "port": 3000
+    }
+  ]
+}

--- a/docs/contact.html
+++ b/docs/contact.html
@@ -18,6 +18,7 @@
       <span>KHASHMERE</span>
     </a>
     <div class="nav-links">
+      <a href="index.html">WHY KHASHMERE</a>
       <a href="pricing.html">PRICING</a>
       <a href="contact.html" class="active">CONTACT</a>
     </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -18,36 +18,25 @@
       <span>KHASHMERE</span>
     </a>
     <div class="nav-links">
+      <a href="index.html" class="active">WHY KHASHMERE</a>
       <a href="pricing.html">PRICING</a>
       <a href="contact.html">CONTACT</a>
     </div>
   </nav>
 
   <main class="landing-container">
-    <!-- Left side: Hero content + Login -->
+    <!-- Left side: Hero content -->
     <div class="landing-left">
       <div class="hero-content">
+        <p class="hero-eyebrow">Why Khashmere</p>
         <h1 class="headline">
-          Premium data platform<br/><em>*Humans included</em>
+          Get your data under control.<br/>
+          Then <em>unlock the AI</em> that fixes what's slowing you down.
         </h1>
-
-        <div class="hero-login">
-          <a href="https://app.fabric.microsoft.com/" class="login-btn" target="_blank" rel="noopener noreferrer">
-            <svg class="microsoft-icon" viewBox="0 0 21 21" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-              <rect x="1" y="1" width="9" height="9" fill="#f25022"/>
-              <rect x="11" y="1" width="9" height="9" fill="#7fba00"/>
-              <rect x="1" y="11" width="9" height="9" fill="#00a4ef"/>
-              <rect x="11" y="11" width="9" height="9" fill="#ffb900"/>
-            </svg>
-            Sign-in with Microsoft Fabric
-          </a>
-
-          <div class="hero-login-divider">
-            <span>or</span>
-          </div>
-
-          <a href="#what-we-do" class="cta">See What We Do</a>
-        </div>
+        <p class="hero-sub">
+          Most vendors pitch first. <em>We teach first</em> — what AI is worth your time, what isn't, and where to begin. Then we build it with you, on a foundation we've made trustworthy.
+        </p>
+        <a href="contact.html" class="cta hero-cta">Book a strategy session</a>
       </div>
     </div>
 
@@ -184,7 +173,7 @@
         <div class="card-pricing">
           <div class="price-block">
             <span class="price-amount">$799</span>
-            <span class="price-period">/month</span>
+            <span class="price-period">USD/month</span>
           </div>
         </div>
         <ul class="card-includes">
@@ -206,7 +195,7 @@
         <div class="card-pricing">
           <div class="price-block">
             <span class="price-amount">$999</span>
-            <span class="price-period">/month</span>
+            <span class="price-period">USD/month</span>
           </div>
         </div>
         <ul class="card-includes">
@@ -228,7 +217,7 @@
         <div class="card-pricing">
           <div class="price-block">
             <span class="price-amount">$1,499</span>
-            <span class="price-period">/month</span>
+            <span class="price-period">USD/month</span>
           </div>
         </div>
         <ul class="card-includes">
@@ -254,17 +243,11 @@
             <img src="assets/connectwise-logo.svg" alt="ConnectWise" class="client-logo">
           </div>
           <div class="client-logo-item">
-            <img src="assets/bullhorn-logo.svg" alt="Bullhorn" class="client-logo">
-          </div>
-          <div class="client-logo-item">
             <img src="assets/momentus-logo.svg" alt="Momentus" class="client-logo">
           </div>
           <!-- Duplicate set for seamless loop -->
           <div class="client-logo-item" aria-hidden="true">
             <img src="assets/connectwise-logo.svg" alt="" class="client-logo">
-          </div>
-          <div class="client-logo-item" aria-hidden="true">
-            <img src="assets/bullhorn-logo.svg" alt="" class="client-logo">
           </div>
           <div class="client-logo-item" aria-hidden="true">
             <img src="assets/momentus-logo.svg" alt="" class="client-logo">

--- a/docs/pricing.html
+++ b/docs/pricing.html
@@ -18,6 +18,7 @@
       <span>KHASHMERE</span>
     </a>
     <div class="nav-links">
+      <a href="index.html">WHY KHASHMERE</a>
       <a href="pricing.html" class="active">PRICING</a>
       <a href="contact.html">CONTACT</a>
     </div>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -121,24 +121,32 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: linear-gradient(180deg, #2a3a4a 0%, #1f2d3a 100%);
   position: relative;
   overflow: hidden;
-  border-radius: 16px;
 }
 
 /* Hero Content */
 .hero-content {
-  text-align: center;
-  max-width: 400px;
+  text-align: left;
+  max-width: 520px;
   width: 100%;
 }
 
+.hero-eyebrow {
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: var(--warm-cream);
+  opacity: 0.5;
+  margin-bottom: 24px;
+}
+
 .headline {
-  font-size: 32px;
+  font-size: 36px;
   font-weight: 400;
-  line-height: 1.5;
-  margin-bottom: 40px;
+  line-height: 1.35;
+  margin-bottom: 28px;
 }
 
 .headline em {
@@ -147,63 +155,26 @@ body {
   font-weight: 400;
 }
 
-/* Hero Login Section */
-.hero-login {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-  align-items: center;
-}
-
-.login-btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 12px;
-  width: 100%;
-  padding: 14px 24px;
-  background: rgba(240, 236, 232, 0.08);
-  border: 1px solid rgba(240, 236, 232, 0.2);
+.hero-sub {
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 1.6;
   color: var(--warm-cream);
-  font-family: "DM Sans", sans-serif;
-  font-size: 14px;
-  letter-spacing: 0.5px;
-  text-decoration: none;
-  cursor: pointer;
-  transition: all 0.3s ease;
+  opacity: 0.75;
+  margin-bottom: 36px;
+  max-width: 480px;
 }
 
-.login-btn:hover {
-  background: rgba(240, 236, 232, 0.12);
-  border-color: rgba(240, 236, 232, 0.35);
+.hero-sub em {
+  font-style: italic;
+  color: var(--warm-gold);
+  opacity: 1;
+  font-weight: 400;
 }
 
-.microsoft-icon {
-  width: 20px;
-  height: 20px;
-}
-
-.hero-login-divider {
-  display: flex;
-  align-items: center;
-  width: 100%;
-  gap: 16px;
-  opacity: 0.4;
-}
-
-.hero-login-divider::before,
-.hero-login-divider::after {
-  content: "";
-  flex: 1;
-  height: 1px;
-  background: var(--warm-cream);
-  opacity: 0.3;
-}
-
-.hero-login-divider span {
-  font-size: 12px;
-  text-transform: uppercase;
-  letter-spacing: 1px;
+.hero-cta {
+  width: auto;
+  display: inline-block;
 }
 
 .cta {
@@ -235,8 +206,8 @@ body {
 }
 
 .brand-logo-large {
-  width: 300px;
-  height: 300px;
+  width: 450px;
+  height: 450px;
   opacity: 0.9;
 }
 
@@ -357,10 +328,6 @@ body {
     font-size: 24px;
   }
 
-  .login-btn {
-    padding: 12px 20px;
-    font-size: 13px;
-  }
 }
 
 /* ==================== */
@@ -374,7 +341,6 @@ body {
   }
 
   .cta,
-  .login-btn,
   .nav-links a,
   .logo {
     transition: none;


### PR DESCRIPTION
- new headline: "Get your data under control. Then unlock the AI that fixes what's slowing you down." Replaces "Premium data platform. Humans included." which gave visitors no recognition of their own situation.
- add WHY KHASHMERE eyebrow + sub paragraph framing the "we teach first, then build" approach as the moat.
- remove Microsoft Fabric login from hero (assumed too much familiarity for first-time visitors); replace with single "Book a strategy session" CTA.
- add WHY KHASHMERE link to nav across all pages, with active state on index.html.
- enlarge constellation visual to 450x450 (per CLAUDE.md spec) and drop the boxed background on the right column so the hero reads as one continuous space.
- remove ~40 lines of unused login/divider CSS.