### PR TITLE
add mobile hamburger nav, full-bleed hero, gold CTA

### DIFF
--- a/docs/contact.html
+++ b/docs/contact.html
@@ -22,7 +22,32 @@
       <a href="pricing.html">PRICING</a>
       <a href="contact.html" class="active">CONTACT</a>
     </div>
+    <button class="nav-toggle" aria-label="Open menu" aria-expanded="false" aria-controls="mobile-menu">
+      <span class="nav-toggle-line"></span>
+      <span class="nav-toggle-line"></span>
+      <span class="nav-toggle-line"></span>
+    </button>
   </nav>
+
+  <div class="mobile-menu" id="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu-header">
+      <a href="index.html" class="logo">
+        <img src="assets/khashmere-icon.svg" alt="" class="logo-icon">
+        <span>KHASHMERE</span>
+      </a>
+      <button class="mobile-menu-close" aria-label="Close menu">
+        <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <path d="M6 6L18 18M6 18L18 6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+        </svg>
+      </button>
+    </div>
+    <nav class="mobile-menu-nav" aria-label="Mobile navigation">
+      <a href="index.html" class="mobile-menu-link">Why Khashmere</a>
+      <a href="pricing.html" class="mobile-menu-link">Pricing</a>
+      <a href="contact.html" class="mobile-menu-link active">Contact</a>
+    </nav>
+    <a href="contact.html" class="mobile-menu-cta">Book a strategy session</a>
+  </div>
 
   <main class="contact-container">
     <div class="contact-content">

--- a/docs/index.html
+++ b/docs/index.html
@@ -22,7 +22,32 @@
       <a href="pricing.html">PRICING</a>
       <a href="contact.html">CONTACT</a>
     </div>
+    <button class="nav-toggle" aria-label="Open menu" aria-expanded="false" aria-controls="mobile-menu">
+      <span class="nav-toggle-line"></span>
+      <span class="nav-toggle-line"></span>
+      <span class="nav-toggle-line"></span>
+    </button>
   </nav>
+
+  <div class="mobile-menu" id="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu-header">
+      <a href="index.html" class="logo">
+        <img src="assets/khashmere-icon.svg" alt="" class="logo-icon">
+        <span>KHASHMERE</span>
+      </a>
+      <button class="mobile-menu-close" aria-label="Close menu">
+        <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <path d="M6 6L18 18M6 18L18 6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+        </svg>
+      </button>
+    </div>
+    <nav class="mobile-menu-nav" aria-label="Mobile navigation">
+      <a href="index.html" class="mobile-menu-link active">Why Khashmere</a>
+      <a href="pricing.html" class="mobile-menu-link">Pricing</a>
+      <a href="contact.html" class="mobile-menu-link">Contact</a>
+    </nav>
+    <a href="contact.html" class="mobile-menu-cta">Book a strategy session</a>
+  </div>
 
   <main class="landing-container">
     <!-- Left side: Hero content -->
@@ -30,8 +55,8 @@
       <div class="hero-content">
         <p class="hero-eyebrow">Why Khashmere</p>
         <h1 class="headline">
-          Get your data under control.<br/>
-          Then <em>unlock the AI</em> that fixes what's slowing you down.
+          <span class="headline-line">Get your data under control.</span>
+          <span class="headline-line">Then <em>unlock the AI</em> that fixes what's slowing you down.</span>
         </h1>
         <p class="hero-sub">
           Most vendors pitch first. <em>We teach first</em> — what AI is worth your time, what isn't, and where to begin. Then we build it with you, on a foundation we've made trustworthy.

--- a/docs/main.js
+++ b/docs/main.js
@@ -10,6 +10,40 @@ if (nav) {
   });
 }
 
+// Mobile menu toggle
+const navToggle = document.querySelector('.nav-toggle');
+const mobileMenu = document.querySelector('.mobile-menu');
+const mobileMenuClose = document.querySelector('.mobile-menu-close');
+const mobileMenuLinks = document.querySelectorAll('.mobile-menu-link, .mobile-menu-cta');
+
+if (navToggle && mobileMenu) {
+  const openMenu = () => {
+    mobileMenu.classList.add('open');
+    mobileMenu.setAttribute('aria-hidden', 'false');
+    navToggle.setAttribute('aria-expanded', 'true');
+    document.documentElement.classList.add('menu-open');
+    document.body.classList.add('menu-open');
+  };
+
+  const closeMenu = () => {
+    mobileMenu.classList.remove('open');
+    mobileMenu.setAttribute('aria-hidden', 'true');
+    navToggle.setAttribute('aria-expanded', 'false');
+    document.documentElement.classList.remove('menu-open');
+    document.body.classList.remove('menu-open');
+  };
+
+  navToggle.addEventListener('click', openMenu);
+  mobileMenuClose?.addEventListener('click', closeMenu);
+  mobileMenuLinks.forEach(link => link.addEventListener('click', closeMenu));
+
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && mobileMenu.classList.contains('open')) {
+      closeMenu();
+    }
+  });
+}
+
 // What We Do - Capability Accordion
 const capabilityItems = document.querySelectorAll('.capability-item');
 const capabilityDetails = document.querySelectorAll('.capability-detail');

--- a/docs/pricing.css
+++ b/docs/pricing.css
@@ -3,7 +3,7 @@
 /* ==================== */
 
 /* Main Content */
-main {
+.pricing-main {
   max-width: 1200px;
   margin: 0 auto;
   padding: 0 48px 80px;

--- a/docs/pricing.html
+++ b/docs/pricing.html
@@ -22,9 +22,34 @@
       <a href="pricing.html" class="active">PRICING</a>
       <a href="contact.html">CONTACT</a>
     </div>
+    <button class="nav-toggle" aria-label="Open menu" aria-expanded="false" aria-controls="mobile-menu">
+      <span class="nav-toggle-line"></span>
+      <span class="nav-toggle-line"></span>
+      <span class="nav-toggle-line"></span>
+    </button>
   </nav>
 
-  <main>
+  <div class="mobile-menu" id="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu-header">
+      <a href="index.html" class="logo">
+        <img src="assets/khashmere-icon.svg" alt="" class="logo-icon">
+        <span>KHASHMERE</span>
+      </a>
+      <button class="mobile-menu-close" aria-label="Close menu">
+        <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <path d="M6 6L18 18M6 18L18 6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+        </svg>
+      </button>
+    </div>
+    <nav class="mobile-menu-nav" aria-label="Mobile navigation">
+      <a href="index.html" class="mobile-menu-link">Why Khashmere</a>
+      <a href="pricing.html" class="mobile-menu-link active">Pricing</a>
+      <a href="contact.html" class="mobile-menu-link">Contact</a>
+    </nav>
+    <a href="contact.html" class="mobile-menu-cta">Book a strategy session</a>
+  </div>
+
+  <main class="pricing-main">
     <!-- Hero Section -->
     <section class="pricing-hero">
       <h1 class="hero-headline"><em>Clear pricing.</em> No surprises.</h1>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -16,6 +16,7 @@ html {
   background: #3d4f61;
   min-height: 100vh;
   scroll-behavior: smooth;
+  overflow-x: hidden;
 }
 
 body {
@@ -95,15 +96,136 @@ body {
 }
 
 /* ==================== */
+/* Mobile Nav Toggle    */
+/* ==================== */
+
+.nav-toggle {
+  display: none;
+  flex-direction: column;
+  justify-content: center;
+  gap: 5px;
+  width: 40px;
+  height: 40px;
+  padding: 8px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+}
+
+.nav-toggle-line {
+  display: block;
+  width: 100%;
+  height: 1.5px;
+  background: var(--warm-cream);
+  opacity: 0.7;
+  transition: opacity 0.3s ease;
+}
+
+.nav-toggle:hover .nav-toggle-line {
+  opacity: 1;
+}
+
+.mobile-menu {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  display: flex;
+  flex-direction: column;
+  padding: 24px;
+  background: linear-gradient(160deg, #3d4f61 0%, #2a3a4a 50%, #1f2d3a 100%);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.3s ease, visibility 0.3s ease;
+}
+
+.mobile-menu.open {
+  opacity: 1;
+  visibility: visible;
+}
+
+.mobile-menu-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 64px;
+}
+
+.mobile-menu-close {
+  width: 40px;
+  height: 40px;
+  padding: 8px;
+  background: transparent;
+  border: none;
+  color: var(--warm-cream);
+  opacity: 0.7;
+  cursor: pointer;
+  transition: opacity 0.3s ease;
+}
+
+.mobile-menu-close:hover {
+  opacity: 1;
+}
+
+.mobile-menu-close svg {
+  width: 100%;
+  height: 100%;
+}
+
+.mobile-menu-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  flex: 1;
+}
+
+.mobile-menu-link {
+  font-size: 28px;
+  font-weight: 400;
+  color: var(--warm-cream);
+  opacity: 0.5;
+  text-decoration: none;
+  transition: opacity 0.3s ease;
+}
+
+.mobile-menu-link:hover,
+.mobile-menu-link.active {
+  opacity: 1;
+}
+
+.mobile-menu-cta {
+  display: block;
+  width: 100%;
+  padding: 16px 28px;
+  margin-bottom: 16px;
+  background: var(--warm-gold);
+  border: none;
+  font-family: "DM Sans", sans-serif;
+  font-size: 14px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  text-align: center;
+  color: var(--deep-navy);
+  text-decoration: none;
+  transition: opacity 0.3s ease;
+}
+
+.mobile-menu-cta:hover {
+  opacity: 0.9;
+}
+
+html.menu-open,
+body.menu-open {
+  overflow: hidden;
+}
+
+/* ==================== */
 /* Landing Split Layout */
 /* ==================== */
 
 .landing-container {
   display: flex;
   min-height: calc(100vh - 96px);
-  border-radius: 24px;
-  margin: 16px auto 0;
-  max-width: calc(100% - 48px);
+  width: 100%;
   overflow: hidden;
 }
 
@@ -113,7 +235,6 @@ body {
   align-items: center;
   justify-content: center;
   padding: 40px;
-  border-radius: 16px;
 }
 
 .landing-right {
@@ -149,6 +270,14 @@ body {
   margin-bottom: 28px;
 }
 
+.headline-line {
+  display: block;
+}
+
+.headline-line + .headline-line {
+  margin-top: 16px;
+}
+
 .headline em {
   font-style: italic;
   color: var(--warm-gold);
@@ -172,9 +301,20 @@ body {
   font-weight: 400;
 }
 
-.hero-cta {
+.cta.hero-cta {
   width: auto;
-  display: inline-block;
+  background: var(--warm-gold);
+  border: none;
+  color: var(--deep-navy);
+  padding: 14px 32px;
+  font-size: 13px;
+  transition: opacity 0.3s ease;
+}
+
+.cta.hero-cta:hover {
+  background: var(--warm-gold);
+  border: none;
+  opacity: 0.85;
 }
 
 .cta {
@@ -273,8 +413,6 @@ body {
   .landing-container {
     flex-direction: column;
     min-height: calc(100vh - 72px);
-    margin: 12px 16px 0;
-    border-radius: 20px;
   }
 
   .landing-left {
@@ -289,11 +427,11 @@ body {
 
 @media (max-width: 768px) {
   .nav-links {
-    gap: 16px;
+    display: none;
   }
 
-  .nav-links a {
-    font-size: 11px;
+  .nav-toggle {
+    display: flex;
   }
 
   .hero-content {
@@ -304,6 +442,10 @@ body {
     font-size: 26px;
     margin-bottom: 32px;
   }
+
+  .headline-line + .headline-line {
+    margin-top: 20px;
+  }
 }
 
 @media (max-width: 480px) {
@@ -313,11 +455,6 @@ body {
 
   .nav.scrolled {
     padding: 12px 16px;
-  }
-
-  .landing-container {
-    margin: 8px 12px 0;
-    border-radius: 16px;
   }
 
   .landing-left {


### PR DESCRIPTION
- Mobile hamburger nav with full-screen drawer (≤768px). Drawer contains Why Khashmere / Pricing / Contact links with active state per page, plus a gold "Book a strategy session" CTA at the bottom. Close via X button, Esc key, or any link click. Body + html scroll fully locked while drawer is open.
- Hero CTA restyled to gold-filled (matching the mobile drawer CTA) with brand-appropriate hover (subtle opacity dim, no jarring color overlay or border change).
- Hero now full-bleed edge-to-edge — removed inset margins, max-width constraint, and rounded corners on .landing-container so the hero reads as one continuous space.
- Wrapped headline in .headline-line spans with explicit margin between lines (16px desktop / 20px mobile) for proper breathing room between the two clauses.
- Scoped pricing.css's global `main {}` rule to `.pricing-main` to prevent it from constraining .landing-container on index.html.
- Cleaned redundant mobile nav rules (gap/font-size adjustments replaced by display:none) and deleted the now-orphaned border-radius
  + margin overrides in 900px and 480px media queries.
- Added overflow-x:hidden on html for safety after layout changes.