### PR TITLE
add Phase 2 foundation section, fix sticky nav, remove What We Do

### DIFF
--- a/.claude/skills/khashmere-brand/SKILL.md
+++ b/.claude/skills/khashmere-brand/SKILL.md
@@ -30,7 +30,9 @@ This is simple. These are real people I can trust.
 **Voice:**
 Sound like an expert who solves the right problem, not just the obvious one. Plain language, direct, confident. Lead with strategy, follow with execution. Acknowledge complexity then simplify it.
 
-**Don't:** Buzzwords, jargon, over-explaining, cold/robotic tone.
+**Positioning:** *Teach first, pitch never.* Most vendors sell before they explain. Khashmere leads with education — what AI is worth your time, what isn't, where to begin — then builds. Never open with a feature list.
+
+**Don't:** Buzzwords, jargon, over-explaining, cold/robotic tone. Never sound like a vendor spec sheet.
 
 ## Visual Identity
 
@@ -66,7 +68,17 @@ background: linear-gradient(160deg, #3d4f61 0%, #2a3a4a 50%, #1f2d3a 100%);
 .headline: 28px, weight 400, line-height 1.5
 .headline em: italic, var(--warm-gold)
 
-/* CTA Button */
+/* Hero eyebrow */
+.hero-eyebrow: 11px, letter-spacing 3px, uppercase, opacity 0.5
+
+/* Hero sub paragraph */
+.hero-sub: 16px, weight 400, line-height 1.7, opacity 0.75
+.hero-sub em: italic, var(--warm-gold)
+
+/* CTA Buttons — two variants */
+/* Primary (hero): gold-filled background, deep navy text */
+.hero-cta: background var(--warm-gold), color var(--deep-navy), 12px, padding 14px 32px, letter-spacing 1px, uppercase
+/* Secondary: transparent with warm cream border */
 .cta: 12px, padding 12px 28px, border 1px solid rgba(240,236,232,0.25), letter-spacing 1px
 
 /* Section Headlines */
@@ -101,6 +113,39 @@ Stagger node delays for organic feel.
 
 - On dark: `#f0ece8` (warm cream)
 - On light: `#1f2d3a` (deep navy)
+
+## Target Audience
+
+**Primary: MSPs (Managed Service Providers)**
+- Exec/IT decision-makers at mid-market MSPs
+- Pain: AI paralysis (don't know where to start), operating blind (no unified reporting), bad data at source, tools bought but not used
+- They are already in the Microsoft ecosystem (Teams, SharePoint, Azure) — don't position Fabric as new, position it as what they already have, finally unified
+- Validated by Mark Clancy's MSP research; Jenn (marketer) confirmed education-first as the moat
+
+**Secondary: Convention centers** *(in progress — rows TBD with Mark's input)*
+
+**What resonates:**
+- "We teach first" — they're burned by vendors who pitch before understanding the problem
+- "No rip-and-replace" — they can't afford downtime or migrations
+- "Foundation we've made trustworthy" — trust is the purchase, not the software
+- Real people, subscription model, with you every step
+
+**What to avoid:**
+- Enterprise language (Fortune 500, Accenture-style positioning feels distant to SMB MSPs)
+- Feature lists before context
+- Anything that sounds like another SaaS vendor
+
+## Page Structure (current)
+
+Sections in order: Hero → Foundation (Phase 2) → Pain Points table (Phase 3, in progress) → Pricing → Client logos → Team → Footer
+
+**Removed:** "What We Do" capability tabs section — replaced by Phase 3 pain points table.
+
+## Section Design Principles
+
+- Prefer **editorial layouts** over card grids. Gold left-border blocks feel warm and conversational; boxed cards feel like vendor spec sheets.
+- Sections flow from education → proof → action. Don't lead with features or pricing.
+- Use eyebrow labels (`font-size: 11px, letter-spacing: 3px, uppercase, warm-gold`) to orient the reader before each section.
 
 ## Application
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -94,94 +94,29 @@
     </div>
   </main>
 
-  <!-- What We Do Section -->
-  <section id="what-we-do" class="what-we-do-section" aria-label="What we do">
-    <div class="what-we-do-header">
-      <h2 class="section-headline"><em>W</em>hat we do</h2>
-      <p class="what-we-do-intro">Data analytics and AI can be overwhelming.<br/>We unify your systems with Microsoft Fabric and Claude.<br/>As a subscription, <em>we're with you every step of the way.</em></p>
-    </div>
-
-    <div class="what-we-do-container">
-      <!-- Left: Capability List -->
-      <div class="capabilities-list">
-        <div class="capability-items">
-          <button class="capability-item active" data-capability="strategy" aria-expanded="true" aria-controls="capability-detail">
-            <svg class="capability-icon" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-              <path d="M12 2L2 7L12 12L22 7L12 2Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-              <path d="M2 17L12 22L22 17" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-              <path d="M2 12L12 17L22 12" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-            </svg>
-            <span class="capability-label">Strategy & Training</span>
-            <div class="capability-line"></div>
-          </button>
-
-          <button class="capability-item" data-capability="engineering" aria-expanded="false" aria-controls="capability-detail">
-            <svg class="capability-icon" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-              <polyline points="16,18 22,12 16,6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-              <polyline points="8,6 2,12 8,18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-              <line x1="14" y1="4" x2="10" y2="20" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
-            </svg>
-            <span class="capability-label">Engineering</span>
-            <div class="capability-line"></div>
-          </button>
-
-          <button class="capability-item" data-capability="platform" aria-expanded="false" aria-controls="capability-detail">
-            <svg class="capability-icon" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-              <rect x="2" y="3" width="20" height="14" rx="2" stroke="currentColor" stroke-width="1.5"/>
-              <path d="M8 21H16" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
-              <path d="M12 17V21" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
-              <circle cx="12" cy="10" r="3" stroke="currentColor" stroke-width="1.5"/>
-            </svg>
-            <span class="capability-label">Data Platform</span>
-            <div class="capability-line"></div>
-          </button>
-        </div>
+  <!-- Phase 2: Foundation section -->
+  <section class="trust-section" aria-label="Why these tools">
+    <p class="trust-eyebrow">THE FOUNDATION</p>
+    <h2 class="trust-headline">
+      <span class="trust-headline-line">We're not introducing something foreign.</span>
+      <em class="trust-headline-line">We're activating what you already have.</em>
+    </h2>
+    <div class="trust-blocks">
+      <div class="trust-block">
+        <img src="assets/microsoft-fabric.png" alt="Microsoft Fabric" class="trust-block-logo trust-block-logo--fabric">
+        <p class="trust-block-name">MICROSOFT FABRIC</p>
+        <p class="trust-block-body">Fortune 500 companies rely on Microsoft Fabric for analytics and insights. We connect your existing vendor systems into Fabric — <em>cleaning your data</em> and surfacing the reporting your team needs to understand what's driving the business.</p>
       </div>
-
-      <!-- Right: Detail Panel with Split View -->
-      <div class="capability-detail-wrapper" id="capability-detail">
-        <div class="capability-detail active" data-capability="strategy">
-          <div class="detail-split">
-            <div class="detail-content">
-              <p class="detail-text">Overwhelmed by AI and data analytics? We'll <em>map your path</em> and train your team to run with it.</p>
-            </div>
-            <div class="detail-visual">
-              <img src="assets/strategy.gif" alt="Strategy and training" class="detail-image">
-            </div>
-          </div>
-        </div>
-
-        <div class="capability-detail" data-capability="engineering">
-          <div class="detail-split">
-            <div class="detail-content">
-              <p class="detail-text">Too many systems that don't talk to each other? We <em>connect them</em> — AI included when it matters.</p>
-            </div>
-            <div class="detail-visual">
-                  <img src="assets/engineering.gif" alt="Microsoft Fabric data platform interface" class="detail-image">
-            </div>
-          </div>
-        </div>
-
-        <div class="capability-detail" data-capability="platform">
-          <div class="detail-split">
-            <div class="detail-content">
-              <p class="detail-text">Microsoft Fabric powers 70% of Fortune 500 analytics. Not on the 500 list yet? Add Claude to the mix and <em>let's fix that.</em></p>
-            </div>
-            <div class="detail-visual">
-              <div class="platform-logos">
-                <img src="assets/microsoft-fabric.png" alt="Microsoft Fabric" class="platform-logo platform-logo-fabric">
-                <svg class="platform-connector" viewBox="0 0 60 40" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-                  <path d="M0 20 Q20 10, 30 20 Q40 30, 60 20" stroke="var(--warm-gold)" stroke-width="1.5" fill="none" opacity="0.35"/>
-                  <circle cx="30" cy="20" r="4" fill="var(--warm-gold)" opacity="0.5" class="connector-node"/>
-                </svg>
-                <img src="assets/claude-logo.svg" alt="Claude AI" class="platform-logo platform-logo-claude">
-              </div>
-            </div>
-          </div>
-        </div>
+      <div class="trust-block">
+        <img src="assets/claude-logo.svg" alt="Claude by Anthropic" class="trust-block-logo trust-block-logo--claude">
+        <p class="trust-block-name">CLAUDE BY ANTHROPIC</p>
+        <p class="trust-block-body">AI is only as useful as the data underneath it. We help you understand what your data can actually answer — then Claude does the reasoning, so your team gets <em>clarity instead of more noise.</em></p>
       </div>
     </div>
+    <p class="trust-footer-line">No rip-and-replace. No new logins. <em class="trust-footer-break">Just your existing tools, finally working together.</em></p>
   </section>
+
+
 
   <!-- Pricing Section -->
   <section class="pricing-section" aria-label="Explore pricing">

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -24,7 +24,6 @@ body {
   background: linear-gradient(160deg, #3d4f61 0%, #2a3a4a 50%, #1f2d3a 100%);
   color: var(--warm-cream);
   min-height: 100vh;
-  overflow-x: hidden;
 }
 
 /* ==================== */
@@ -491,48 +490,8 @@ a:focus-visible {
 }
 
 /* ==================== */
-/* What We Do Section   */
+/* Section Headlines    */
 /* ==================== */
-
-.what-we-do-section {
-  padding: 120px 40px;
-  background: var(--slate);
-  scroll-margin-top: 40px;
-}
-
-.what-we-do-header {
-  text-align: center;
-  max-width: 700px;
-  margin: 0 auto 64px;
-}
-
-.what-we-do-header .section-headline {
-  margin-bottom: 16px;
-}
-
-.what-we-do-intro {
-  font-size: 16px;
-  color: rgba(240, 236, 232, 0.8);
-  line-height: 1.6;
-  text-align: center;
-}
-
-.what-we-do-intro em {
-  font-style: italic;
-  color: var(--warm-gold);
-}
-
-.what-we-do-container {
-  display: flex;
-  gap: 80px;
-  max-width: 1100px;
-  margin: 0 auto;
-  align-items: stretch;
-}
-
-.capabilities-list {
-  flex: 0 0 320px;
-}
 
 .section-headline {
   font-size: 42px;
@@ -547,295 +506,11 @@ a:focus-visible {
   color: var(--warm-gold);
 }
 
-.capability-items {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.capability-item {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-  padding: 20px 24px;
-  background: transparent;
-  border: 1px solid transparent;
-  border-radius: 8px;
-  cursor: pointer;
-  transition: all 0.3s ease;
-  text-align: left;
-  width: 100%;
-  font-family: "DM Sans", sans-serif;
-  color: var(--warm-cream);
-  opacity: 0.5;
-  position: relative;
-}
-
-.capability-item:hover {
-  opacity: 0.8;
-  background: rgba(240, 236, 232, 0.03);
-}
-
-.capability-item.active {
-  opacity: 1;
-  background: rgba(240, 236, 232, 0.05);
-  border-color: rgba(212, 175, 130, 0.3);
-}
-
-.capability-icon {
-  width: 24px;
-  height: 24px;
-  flex-shrink: 0;
-  color: var(--warm-cream);
-  transition: color 0.3s ease;
-}
-
-.capability-item.active .capability-icon {
-  color: var(--warm-gold);
-}
-
-.capability-label {
-  font-size: 13px;
-  font-weight: 400;
-  letter-spacing: 2px;
-  text-transform: uppercase;
-  flex: 1;
-}
-
-.capability-line {
-  position: absolute;
-  right: 0;
-  top: 50%;
-  transform: translateY(-50%);
-  width: 0;
-  height: 2px;
-  background: var(--warm-gold);
-  transition: width 0.3s ease;
-}
-
-.capability-item.active .capability-line {
-  width: 40px;
-}
-
-/* Detail Panel - Right Side */
-.capability-detail-wrapper {
-  flex: 1;
-  position: relative;
-  align-self: stretch;
-}
-
-.capability-detail {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  opacity: 0;
-  transform: translateY(12px);
-  transition: opacity 0.4s ease, transform 0.4s ease;
-  pointer-events: none;
-}
-
-.capability-detail.active {
-  opacity: 1;
-  transform: translateY(0);
-  pointer-events: auto;
-  position: relative;
-  height: 100%;
-}
-
-.detail-split {
-  display: flex;
-  gap: 0;
-  background: rgba(31, 45, 58, 0.6);
-  border-radius: 16px;
-  overflow: hidden;
-  border: 1px solid rgba(240, 236, 232, 0.08);
-  height: 100%;
-}
-
-.detail-visual {
-  flex: 1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: linear-gradient(180deg, rgba(42, 58, 74, 0.8) 0%, rgba(31, 45, 58, 0.8) 100%);
-  padding: 40px;
-}
-
-.detail-placeholder {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-  height: 200px;
-  border: 2px dashed rgba(240, 236, 232, 0.1);
-  border-radius: 12px;
-  color: var(--warm-cream);
-}
-
-.placeholder-icon {
-  width: 80px;
-  height: 80px;
-  opacity: 0.4;
-}
-
-.detail-image-container {
-  width: 100%;
-  height: 200px;
-  border-radius: 12px;
-  overflow: hidden;
-}
-
-.detail-image {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  transform: scale(1.1);
-  transition: transform 0.5s ease;
-}
-
-.detail-image-container:hover .detail-image {
-  transform: scale(1);
-}
-
-/* Platform Logos - Horizontal with Connector */
-.platform-logos {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  gap: 0;
-}
-
-.platform-logo {
-  object-fit: contain;
-}
-
-.platform-logo-fabric {
-  width: 100px;
-  height: auto;
-}
-
-.platform-logo-claude {
-  width: 56px;
-  height: auto;
-  margin-left: 8px;
-}
-
-.platform-connector {
-  width: 60px;
-  height: 40px;
-}
-
-.connector-node {
-  animation: pulse 6s ease-in-out infinite;
-}
-
-.detail-content {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  padding: 48px 40px;
-  background: rgba(240, 236, 232, 0.02);
-}
-
-.detail-text {
-  font-size: 16px;
-  font-weight: 400;
-  line-height: 1.6;
-  color: var(--warm-cream);
-  opacity: 0.8;
-}
-
-.detail-text em {
-  font-style: italic;
-  color: var(--warm-gold);
-}
-
-/* Responsive - What We Do */
 @media (max-width: 900px) {
-  .what-we-do-section {
-    padding: 80px 24px;
-  }
-
-  .what-we-do-header {
-    margin-bottom: 48px;
-  }
-
-  .what-we-do-header .section-headline {
-    font-size: 32px;
-  }
-
-  .what-we-do-intro {
-    font-size: 15px;
-  }
-
-  .what-we-do-container {
-    flex-direction: column;
-    gap: 48px;
-  }
-
-  .capabilities-list {
-    flex: none;
-    width: 100%;
-  }
-
   .section-headline {
     font-size: 32px;
     text-align: center;
     margin-bottom: 32px;
-  }
-
-  .capability-items {
-    flex-direction: row;
-    flex-wrap: wrap;
-    justify-content: center;
-    gap: 12px;
-  }
-
-  .capability-item {
-    width: auto;
-    padding: 12px 20px;
-  }
-
-  .capability-line {
-    display: none;
-  }
-
-  .capability-detail-wrapper {
-    min-height: auto;
-  }
-
-  .detail-split {
-    flex-direction: column;
-  }
-
-  .detail-visual {
-    min-height: 200px;
-    padding: 32px;
-  }
-
-  .detail-content {
-    padding: 32px 24px;
-  }
-
-  .detail-text {
-    font-size: 16px;
-  }
-
-  .capability-label {
-    font-size: 11px;
-  }
-}
-
-@media (max-width: 480px) {
-  .capability-items {
-    flex-direction: column;
-  }
-
-  .capability-item {
-    width: 100%;
   }
 }
 
@@ -1526,5 +1201,137 @@ a:focus-visible {
 @media (max-width: 480px) {
   .footer-v1.footer-minimal {
     padding: 20px 16px;
+  }
+}
+
+/* ========================= */
+/* Trust / Foundation Section */
+/* ========================= */
+
+.trust-section {
+  padding: 80px 40px;
+  background: var(--deep-navy);
+  text-align: center;
+}
+
+.trust-eyebrow {
+  font-size: 11px;
+  letter-spacing: 3px;
+  text-transform: uppercase;
+  color: var(--warm-gold);
+  opacity: 0.8;
+  margin-bottom: 24px;
+}
+
+.trust-headline {
+  font-size: 32px;
+  font-weight: 400;
+  line-height: 1.5;
+  color: var(--warm-cream);
+  max-width: 640px;
+  margin: 0 auto 56px;
+}
+
+.trust-headline em {
+  font-style: italic;
+  color: var(--warm-gold);
+}
+
+.trust-footer-line {
+  font-size: 18px;
+  font-weight: 400;
+  color: var(--warm-cream);
+  opacity: 0.75;
+  margin-top: 56px;
+  line-height: 1.6;
+  max-width: 560px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.trust-footer-line em {
+  font-style: italic;
+  color: var(--warm-gold);
+  opacity: 1;
+}
+
+.trust-footer-break {
+  display: block;
+  margin-top: 6px;
+}
+
+.trust-blocks {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 56px;
+  max-width: 760px;
+  margin: 0 auto;
+  text-align: left;
+}
+
+.trust-block {
+  border-left: 2px solid var(--warm-gold);
+  padding-left: 28px;
+}
+
+.trust-block-logo {
+  display: block;
+  height: 26px;
+  width: auto;
+  object-fit: contain;
+  margin-bottom: 18px;
+  opacity: 0.8;
+}
+
+.trust-block-logo--claude {
+  height: 20px;
+}
+
+.trust-block-name {
+  font-size: 11px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: var(--warm-gold);
+  opacity: 0.7;
+  margin-bottom: 14px;
+}
+
+.trust-block-body {
+  font-size: 15px;
+  line-height: 1.75;
+  color: var(--warm-cream);
+  opacity: 0.72;
+}
+
+.trust-block-body em {
+  font-style: italic;
+  color: var(--warm-gold);
+  opacity: 1;
+}
+
+@media (max-width: 768px) {
+  .trust-section {
+    padding: 60px 24px;
+  }
+
+  .trust-headline {
+    font-size: 24px;
+  }
+
+  .trust-headline-line {
+    display: block;
+  }
+
+  .trust-headline-line + .trust-headline-line {
+    margin-top: 12px;
+  }
+
+  .trust-blocks {
+    grid-template-columns: 1fr;
+    gap: 32px;
+  }
+
+  .trust-footer-line {
+    font-size: 16px;
   }
 }


### PR DESCRIPTION
- Add "The Foundation" trust section between hero and pricing: two editorial blocks (gold left border, no cards) for Microsoft Fabric and Claude by Anthropic with brand logos, education-first copy, and a closing statement that breaks onto its own line
- Fix sticky nav: remove overflow-x:hidden from body (was making body a scroll container, preventing position:sticky from firing)
- Remove "What We Do" capability tabs section and all associated CSS (~350 lines) — replaced by Phase 3 pain points table
- Update khashmere-brand skill with target audience (MSPs), teach-first positioning, CTA variants, section design principles, and current page structure