### PR TITLE
add Who We Help pain points table section

### DIFF
--- a/docs/contact.css
+++ b/docs/contact.css
@@ -93,7 +93,7 @@
 }
 
 .contact-card-body {
-  padding-left: 0px;
+  padding-left: 0;
 }
 
 .contact-value {
@@ -223,10 +223,6 @@
   .contact-card {
     padding: 16px 20px;
     text-align: center;
-  }
-
-  .contact-card-body {
-    padding-left: 0;
   }
 
   .contact-card-header {

--- a/docs/index.html
+++ b/docs/index.html
@@ -118,6 +118,78 @@
 
 
 
+  <!-- Pain Points Section -->
+  <section class="pain-section" aria-label="Where leaders get stuck">
+    <div class="pain-section-inner">
+      <h2 class="pain-headline">Who we help</h2>
+      <div class="pain-table" role="table" aria-label="Where leaders get stuck">
+
+        <div class="pain-table-header" role="row">
+          <div class="pain-col-persona" role="columnheader">Role</div>
+          <div class="pain-col-problem" role="columnheader">Pain Point</div>
+          <div class="pain-col-help" role="columnheader">How Khashmere Helps</div>
+        </div>
+
+        <div class="pain-row" role="row">
+          <div class="pain-col-persona" role="cell">
+            <span class="pain-persona-label">Strategy</span>
+          </div>
+          <div class="pain-col-problem" role="cell">
+            <h3 class="pain-row-title"><em>AI Paralysis</em></h3>
+            <p class="pain-row-desc">New tools, new models, new announcements — every week. It's hard to know what's actually relevant to your business and what's just noise.</p>
+          </div>
+          <div class="pain-col-help" role="cell">
+            <p class="pain-mobile-label" aria-hidden="true">How Khashmere Helps</p>
+            <p class="pain-row-resolution">We educate before we build. Working alongside your team, we help you understand where AI genuinely fits your business — and where it doesn't — then focus on what will actually move the needle.</p>
+          </div>
+        </div>
+
+        <div class="pain-row" role="row">
+          <div class="pain-col-persona" role="cell">
+            <span class="pain-persona-label">Strategy</span>
+          </div>
+          <div class="pain-col-problem" role="cell">
+            <h3 class="pain-row-title"><em>Operating Blind</em></h3>
+            <p class="pain-row-desc">Key numbers live in different systems, reporting is manual, and decisions get made on instinct instead of trusted data.</p>
+          </div>
+          <div class="pain-col-help" role="cell">
+            <p class="pain-mobile-label" aria-hidden="true">How Khashmere Helps</p>
+            <p class="pain-row-resolution">We connect your financial, operational, and service data so leadership gets a reliable view of margin, utilization, and performance.</p>
+          </div>
+        </div>
+
+        <div class="pain-row" role="row">
+          <div class="pain-col-persona" role="cell">
+            <span class="pain-persona-label">Operations</span>
+          </div>
+          <div class="pain-col-problem" role="cell">
+            <h3 class="pain-row-title"><em>Bad Data at the Source</em></h3>
+            <p class="pain-row-desc">Inconsistent inputs, weak documentation, and messy records make reporting unreliable and AI outputs worse.</p>
+          </div>
+          <div class="pain-col-help" role="cell">
+            <p class="pain-mobile-label" aria-hidden="true">How Khashmere Helps</p>
+            <p class="pain-row-resolution">We fix the foundation first — cleaning up operational data so reporting, automation, and AI can actually work.</p>
+          </div>
+        </div>
+
+        <div class="pain-row" role="row">
+          <div class="pain-col-persona" role="cell">
+            <span class="pain-persona-label">Operations</span>
+          </div>
+          <div class="pain-col-problem" role="cell">
+            <h3 class="pain-row-title"><em>Tools Bought, Not Used</em></h3>
+            <p class="pain-row-desc">Platforms are purchased, partially implemented, then abandoned. The stack grows, but the value doesn't.</p>
+          </div>
+          <div class="pain-col-help" role="cell">
+            <p class="pain-mobile-label" aria-hidden="true">How Khashmere Helps</p>
+            <p class="pain-row-resolution">We stay involved — helping teams activate what they own, manage adoption over time, and turn underused platforms into working systems.</p>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </section>
+
   <!-- Team Section -->
   <section class="team-section" aria-label="Meet the team">
     <h2 class="team-headline"><em>Y</em>our team</h2>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -489,30 +489,6 @@ a:focus-visible {
   outline-offset: 4px;
 }
 
-/* ==================== */
-/* Section Headlines    */
-/* ==================== */
-
-.section-headline {
-  font-size: 42px;
-  font-weight: 400;
-  line-height: 1.5;
-  margin-bottom: 48px;
-  color: var(--warm-cream);
-}
-
-.section-headline em {
-  font-style: italic;
-  color: var(--warm-gold);
-}
-
-@media (max-width: 900px) {
-  .section-headline {
-    font-size: 32px;
-    text-align: center;
-    margin-bottom: 32px;
-  }
-}
 
 /* ==================== */
 /* Team Section          */
@@ -886,7 +862,7 @@ a:focus-visible {
 /* ========================= */
 
 .trust-section {
-  padding: 80px 40px;
+  padding: 80px 40px 24px;
   background: var(--deep-navy);
   text-align: center;
 }
@@ -1010,5 +986,133 @@ a:focus-visible {
 
   .trust-footer-line {
     font-size: 16px;
+  }
+}
+
+/* ========================= */
+/* Pain Points Section       */
+/* ========================= */
+
+.pain-section {
+  padding: 24px 40px 96px;
+  background: var(--deep-navy);
+}
+
+.pain-section-inner {
+  max-width: 1280px;
+  margin: 0 auto;
+}
+
+.pain-headline {
+  font-size: 36px;
+  font-weight: 400;
+  line-height: 1.4;
+  color: var(--warm-cream);
+  margin-bottom: 52px;
+  max-width: 520px;
+}
+
+.pain-table {
+  border-top: 1px solid rgba(240, 236, 232, 0.1);
+}
+
+.pain-table-header {
+  display: grid;
+  grid-template-columns: 160px 1fr 1fr;
+  gap: 0 48px;
+  padding: 14px 0;
+  border-bottom: 1px solid rgba(240, 236, 232, 0.1);
+}
+
+.pain-table-header > div {
+  font-size: 13px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: var(--warm-gold);
+  opacity: 0.55;
+}
+
+.pain-row {
+  display: grid;
+  grid-template-columns: 160px 1fr 1fr;
+  gap: 0 48px;
+  padding: 36px 0;
+  border-bottom: 1px solid rgba(240, 236, 232, 0.08);
+  align-items: start;
+}
+
+.pain-persona-label {
+  font-size: 11px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: var(--warm-gold);
+  opacity: 0.7;
+  padding-top: 4px;
+  display: block;
+}
+
+.pain-row-title {
+  font-size: 20px;
+  font-weight: 400;
+  font-style: italic;
+  color: var(--warm-gold);
+  margin-bottom: 10px;
+  line-height: 1.3;
+}
+
+
+.pain-row-desc {
+  font-size: 14px;
+  line-height: 1.75;
+  color: var(--warm-cream);
+  opacity: 0.6;
+}
+
+.pain-row-resolution {
+  font-size: 14px;
+  line-height: 1.75;
+  color: var(--warm-cream);
+  opacity: 0.82;
+  padding-top: 4px;
+}
+
+.pain-mobile-label {
+  display: none;
+  font-size: 10px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: var(--warm-gold);
+  opacity: 0.55;
+  margin-bottom: 8px;
+}
+
+@media (max-width: 768px) {
+  .pain-section {
+    padding: 72px 24px;
+  }
+
+  .pain-headline {
+    font-size: 28px;
+    margin-bottom: 40px;
+  }
+
+  .pain-table-header {
+    display: none;
+  }
+
+  .pain-row {
+    grid-template-columns: 1fr;
+    gap: 12px;
+    padding: 28px 0;
+  }
+
+  .pain-mobile-label {
+    display: block;
+  }
+}
+
+@media (max-width: 480px) {
+  .pain-section {
+    padding: 64px 16px;
   }
 }


### PR DESCRIPTION
- Add 4-row 3-column editorial table (Role / Pain Point / How Khashmere Helps) between Foundation and Team sections
- Personas: Strategy (AI Paralysis, Operating Blind) and Operations (Bad Data at the Source, Tools Bought Not Used)
- Mobile layout collapses to single column with inline HOW KHASHMERE HELPS labels
- Tighten spacing between Foundation and Who We Help sections
- Remove unused CSS: .pain-eyebrow, .pain-headline em, .pain-row-title em, redundant contact.css padding override