### PR TITLE
constrain CTA card width, restore footer spacing, prune unused CSS vars

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,7 +1,5 @@
 :root {
-  --soft-navy: #3d4f61;
   --deep-navy: #1f2d3a;
-  --slate: #2a3a4a;
   --warm-cream: #f0ece8;
   --warm-gold: #d4af82;
 }
@@ -495,7 +493,7 @@ a:focus-visible {
 /* ==================== */
 
 .team-section {
-  padding: 80px 40px 0;
+  padding: 80px 40px 80px;
   background: var(--deep-navy);
   text-align: center;
 }
@@ -519,6 +517,9 @@ a:focus-visible {
 .team-section .cta-section {
   margin-top: 72px;
   margin-bottom: 0;
+  max-width: 1104px;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .team-grid {


### PR DESCRIPTION
- Constrain index CTA card to max-width 1104px to match pricing page width
- Restore 80px bottom padding on team section so CTA-to-footer gap matches pricing
- Remove unused --soft-navy and --slate custom properties from styles.css